### PR TITLE
fix: restore SQL explanation links in OpenAI route

### DIFF
--- a/server/api/openai.post.ts
+++ b/server/api/openai.post.ts
@@ -1,5 +1,6 @@
 // server/api/openai.post.ts
 import { defineEventHandler, readBody } from 'h3'
+import { useSqlExplanationLinks } from '~/composables/useSqlExplanationLinks'
 
 export default defineEventHandler(async (event) => {
     const { prompt, sqlQuery, question, userPrompt } = await readBody(event)


### PR DESCRIPTION
## Summary
- import `useSqlExplanationLinks` directly in OpenAI API route to resolve auto-import error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689851f0fd40832c8664ec23f9797ab1